### PR TITLE
Change the cli script so it works on Linux

### DIFF
--- a/packages/cli/bin/run
+++ b/packages/cli/bin/run
@@ -1,4 +1,5 @@
-#!/usr/bin/env node --experimental-repl-await
+#!/bin/sh
+//usr/bin/env node --experimental-repl-await "$0" "$@"; exit $?
 
 require = require('esm')(module, { mode: 'auto' })
 require('@oclif/command')


### PR DESCRIPTION
Apparently shebang lines with arguments aren't supported in Linux, so we need a hack in order to make `node --experimental-repl-await` work.

More info if you're curious: https://unix.stackexchange.com/questions/63979/shebang-line-with-usr-bin-env-command-argument-fails-on-linux