### PR TITLE
Use `rpc-handler` in the daemon and update client

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@
 #
 [ignore]
 <PROJECT_ROOT>/lib/.*
+.*/node_modules/oboe/test/.*
 
 [include]
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "license": "MIT",
   "private": true,
   "workspaces": {
-    "packages": ["packages/*"],
+    "packages": [
+      "packages/*"
+    ],
     "nohoist": [
       "**/@mainframe/rpc-*",
       "**/@mainframe/secure-file",
@@ -21,10 +23,12 @@
       "**/electron-webpack",
       "**/erebos-*",
       "**/es6-error",
+      "**/fastest-validator",
       "**/form-data",
       "**/fs-extra",
       "**/nanoid",
       "**/node-fetch",
+      "**/oboe",
       "**/react",
       "**/react-dom",
       "**/read-config-file",
@@ -39,8 +43,7 @@
   },
   "scripts": {
     "flow:create-symlinks": "flow-mono create-symlinks .flowconfig",
-    "flow:install-types":
-      "flow-mono install-types --overwrite --ignoreDeps=dev",
+    "flow:install-types": "flow-mono install-types --overwrite --ignoreDeps=dev",
     "flow:reinstall": "lerna exec del flow-typed && yarn flow:install-types",
     "flow:align": "flow-mono align-versions",
     "flow:bootstrap": "yarn flow:create-symlinks && yarn flow:install-types",
@@ -55,7 +58,7 @@
     "start": "yarn build && yarn test"
   },
   "resolutions": {
-    "esm": "3.0.72"
+    "esm": "3.0.74"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -69,7 +72,7 @@
     "babel-preset-env": "^1.7.0",
     "babel-preset-flow": "^6.23.0",
     "del-cli": "^1.1.0",
-    "eslint": "^5.0.1",
+    "eslint": "^5.2.0",
     "eslint-config-mainframe": "^1.4.0",
     "flow-bin": "^0.77.0",
     "flow-copy-source": "^2.0.1",

--- a/packages/app-permissions/__tests__/index.js
+++ b/packages/app-permissions/__tests__/index.js
@@ -1,8 +1,8 @@
 import { EMPTY_DEFINITIONS, mergeGrantsToDetails } from '../lib'
 
 describe('EMPTY_DEFINITIONS', () => {
-  it('has HTTPS_REQUEST', () => {
-    expect(EMPTY_DEFINITIONS).toHaveProperty('HTTPS_REQUEST')
+  it('has WEB_REQUEST', () => {
+    expect(EMPTY_DEFINITIONS).toHaveProperty('WEB_REQUEST')
   })
 })
 
@@ -10,14 +10,14 @@ describe('mergeGrantsToDetails', () => {
   it('merges', () => {
     const appGrants = {
       WEB3_SEND: false,
-      HTTPS_REQUEST: {
+      WEB_REQUEST: {
         granted: ['https://google.com', 'https://twitter.com'],
         denied: [],
       },
     }
     const userGrants = {
       LOCATION_GET: true,
-      HTTPS_REQUEST: {
+      WEB_REQUEST: {
         granted: ['https://mainframe.com'],
         denied: ['https://facebook.com'],
       },
@@ -27,7 +27,7 @@ describe('mergeGrantsToDetails', () => {
       app: appGrants,
       user: userGrants,
       session: {
-        HTTPS_REQUEST: {
+        WEB_REQUEST: {
           granted: [
             'https://google.com',
             'https://twitter.com',
@@ -43,14 +43,14 @@ describe('mergeGrantsToDetails', () => {
     expect(mergeGrantsToDetails(appGrants, userGrants)).toEqual(details)
   })
 
-  it('session HTTPS_REQUEST grants are concatenated', () => {
+  it('session WEB_REQUEST grants are concatenated', () => {
     const g1 = ['https://google.com', 'https://twitter.com']
     const g2 = ['https://mainframe.com']
     const result = mergeGrantsToDetails(
-      { HTTPS_REQUEST: { granted: g1, denied: [] } },
-      { HTTPS_REQUEST: { granted: g2, denied: [] } },
+      { WEB_REQUEST: { granted: g1, denied: [] } },
+      { WEB_REQUEST: { granted: g2, denied: [] } },
     )
-    expect(result.session.HTTPS_REQUEST.granted).toEqual([
+    expect(result.session.WEB_REQUEST.granted).toEqual([
       'https://google.com',
       'https://twitter.com',
       'https://mainframe.com',

--- a/packages/app-permissions/src/types.js
+++ b/packages/app-permissions/src/types.js
@@ -7,17 +7,17 @@ export type PermissionKeyBasic =
   | 'SWARM_UPLOAD'
   | 'WEB3_CALL'
   | 'WEB3_SEND'
-export type PermissionKey = 'HTTPS_REQUEST' | PermissionKeyBasic
+export type PermissionKey = 'WEB_REQUEST' | PermissionKeyBasic
 
-export type HTTPSRequestDefinition = Array<string>
+export type WebRequestDefinition = Array<string>
 
 export type PermissionsDefinitions = {
-  HTTPS_REQUEST: HTTPSRequestDefinition,
+  WEB_REQUEST: WebRequestDefinition,
   [PermissionKeyBasic]: boolean,
 }
 
 export type PartialPermissionsDefinitions = {
-  HTTPS_REQUEST?: HTTPSRequestDefinition,
+  WEB_REQUEST?: WebRequestDefinition,
   [PermissionKeyBasic]: boolean,
 }
 
@@ -28,13 +28,13 @@ export type PermissionsDefinitionsDifference = {
   unchanged: PartialPermissionsDefinitions,
 }
 
-export type HTTPSRequestGrant = {
-  granted: HTTPSRequestDefinition,
-  denied: HTTPSRequestDefinition,
+export type WebRequestGrant = {
+  granted: WebRequestDefinition,
+  denied: WebRequestDefinition,
 }
 
 export type PermissionsGrants = {
-  HTTPS_REQUEST: HTTPSRequestGrant,
+  WEB_REQUEST: WebRequestGrant,
   [PermissionKeyBasic]: boolean,
 }
 
@@ -60,6 +60,6 @@ export type PermissionsDetails = { [PermissionLifetime]: PermissionsGrants }
 export type PermissionCheckResult =
   | 'unknown_key' // Not a valid permission key
   | 'not_set' // Valid key but no value
-  | 'invalid_input' // Special for HTTPS_REQUEST: domain not provided
+  | 'invalid_input' // Special for WEB_REQUEST: domain not provided
   | 'granted'
   | 'denied'

--- a/packages/client/__tests__/client.js
+++ b/packages/client/__tests__/client.js
@@ -17,13 +17,4 @@ describe('client', () => {
     expect(client._rpc.request).toHaveBeenCalledTimes(1)
     expect(client._rpc.request).toHaveBeenCalledWith('api_version')
   })
-
-  it('has a validateManifest() method', async () => {
-    const manifest = { id: 'test' }
-    await client.validateManifest(manifest)
-    expect(client._rpc.request).toHaveBeenCalledTimes(1)
-    expect(client._rpc.request).toHaveBeenCalledWith('app_validateManifest', [
-      manifest,
-    ])
-  })
 })

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -11,7 +11,7 @@
     "test:types": "flow check"
   },
   "dependencies": {
-    "@mainframe/rpc-ipc": "^0.2.0",
+    "@mainframe/rpc-ipc": "^0.2.3",
     "rxjs": "^6.2.1"
   },
   "devDependencies": {

--- a/packages/client/src/index.js
+++ b/packages/client/src/index.js
@@ -1,9 +1,6 @@
 // @flow
 
-import type {
-  ManifestData,
-  ManifestValidationResult,
-} from '@mainframe/app-manifest'
+import type { ManifestData } from '@mainframe/app-manifest'
 import type {
   PermissionCheckResult,
   PermissionGrant,
@@ -69,21 +66,21 @@ export default class MainframeClient {
   // Vault
 
   createVault(path: string, password: string): Promise<void> {
-    return this._rpc.request('vault_create', [path, password])
+    return this._rpc.request('vault_create', { path, password })
   }
 
   openVault(path: string, password: string): Promise<void> {
-    return this._rpc.request('vault_open', [path, password])
+    return this._rpc.request('vault_open', { path, password })
   }
 
   // Identities
 
   createUserIdentity(data?: Object = {}): Promise<{ id: ID }> {
-    return this._rpc.request('identity_createUser', [data])
+    return this._rpc.request('identity_createUser', { data })
   }
 
   createDeveloperIdentity(data?: Object = {}): Promise<{ id: ID }> {
-    return this._rpc.request('identity_createDeveloper', [data])
+    return this._rpc.request('identity_createDeveloper', { data })
   }
 
   getOwnUserIdentities(): Promise<{ developers: Array<OwnUser> }> {
@@ -92,14 +89,6 @@ export default class MainframeClient {
 
   getOwnDeveloperIdentities(): Promise<{ users: Array<OwnUser> }> {
     return this._rpc.request('identity_getOwnDevelopers')
-  }
-
-  // App creation
-
-  validateManifest(
-    manifest: ManifestData,
-  ): Promise<{ result: ManifestValidationResult }> {
-    return this._rpc.request('app_validateManifest', [manifest])
   }
 
   // App lifecycle
@@ -113,19 +102,19 @@ export default class MainframeClient {
     userID: ID,
     settings: AppUserSettings,
   ): Promise<ID> {
-    return this._rpc.request('app_install', [manifest, userID, settings])
+    return this._rpc.request('app_install', { manifest, userID, settings })
   }
 
   openApp(appID: ID, userID: ID): Promise<ClientSession> {
-    return this._rpc.request('app_open', [appID, userID])
+    return this._rpc.request('app_open', { appID, userID })
   }
 
   closeApp(sessID: string): Promise<void> {
-    return this._rpc.request('app_close', [sessID])
+    return this._rpc.request('app_close', { sessID })
   }
 
   removeApp(appID: ID): Promise<void> {
-    return this._rpc.request('app_remove', [appID])
+    return this._rpc.request('app_remove', { appID })
   }
 
   // App permissions
@@ -135,7 +124,7 @@ export default class MainframeClient {
     key: PermissionKey,
     input?: ?string,
   ): Promise<{ result: PermissionCheckResult }> {
-    return this._rpc.request('app_checkPermission', [sessID, key, input])
+    return this._rpc.request('app_checkPermission', { sessID, key, input })
   }
 
   setAppPermission(
@@ -143,12 +132,12 @@ export default class MainframeClient {
     key: PermissionKey,
     value: PermissionGrant,
   ): Promise<void> {
-    return this._rpc.request('app_setPermission', [sessID, key, value])
+    return this._rpc.request('app_setPermission', { sessID, key, value })
   }
 
   // Infrastructure interactions
 
   requestWeb3(sessID: ID, method: string, params?: any): Promise<any> {
-    return this._rpc.request('web3_request', [sessID, method, params])
+    return this._rpc.request('web3_request', { sessID, method, params })
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -14,7 +14,7 @@
     "@mainframe/utils-id": "^0.1.0",
     "conf": "^2.0.0",
     "env-paths": "^1.0.0",
-    "esm": "3.0.72",
+    "esm": "3.0.74",
     "fs-extra": "^7.0.0"
   },
   "devDependencies": {

--- a/packages/daemon/__tests__/rpc.js
+++ b/packages/daemon/__tests__/rpc.js
@@ -4,29 +4,4 @@ describe('RPC methods', () => {
   it('"api_version" returns the version', () => {
     expect(methods.api_version()).toBe(0.1)
   })
-
-  it('"app_validateManifest" returns the ManifestValidationResult', () => {
-    const invalidManifest = {
-      id: '1234',
-      author: {},
-    }
-    expect(methods.app_validateManifest(null, [invalidManifest])).toEqual({
-      result: 'invalid_author',
-    })
-
-    const validManifest = {
-      id: '1234',
-      author: { id: '1234' },
-      name: 'test app',
-      version: '1.2.3',
-      contentsHash: '1234',
-      permissions: {
-        required: {},
-        optional: {},
-      },
-    }
-    expect(methods.app_validateManifest(null, [validManifest])).toEqual({
-      result: 'valid',
-    })
-  })
 })

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -31,7 +31,8 @@
     "@mainframe/app-manifest": "*",
     "@mainframe/app-permissions": "*",
     "@mainframe/config": "*",
-    "@mainframe/rpc-error": "^0.1.0",
+    "@mainframe/rpc-error": "^0.2.1",
+    "@mainframe/rpc-handler": "^0.1.0",
     "@mainframe/rpc-node": "^0.2.0",
     "@mainframe/secure-file": "^0.1.0",
     "@mainframe/utils-base64": "^0.1.0",
@@ -42,7 +43,7 @@
     "@oclif/plugin-help": "^2.0.5",
     "debug": "^3.1.0",
     "erebos-api-bzz-node": "^0.3.3",
-    "esm": "3.0.72",
+    "esm": "3.0.74",
     "fs-extra": "^7.0.0",
     "rxjs": "^6.2.0"
   },

--- a/packages/daemon/src/app/App.js
+++ b/packages/daemon/src/app/App.js
@@ -2,7 +2,7 @@
 
 import type { ManifestData } from '@mainframe/app-manifest'
 import {
-  createHTTPSRequestGrant,
+  createWebRequestGrant,
   mergeGrantsToDetails,
   type PermissionGrant, // eslint-disable-line import/named
   type PermissionKey, // eslint-disable-line import/named
@@ -16,7 +16,7 @@ import Session from './Session'
 
 const DEFAULT_SETTINGS = {
   permissions: {
-    HTTPS_REQUEST: [],
+    WEB_REQUEST: [],
   },
   permissionsChecked: false,
 }
@@ -130,8 +130,8 @@ export default class App {
   setPermission(userID: ID, key: PermissionKey, value: PermissionGrant): void {
     const { permissions } = this.getSettings(userID)
     if (
-      (key === 'HTTPS_REQUEST' && typeof value === 'object') ||
-      (key !== 'HTTPS_REQUEST' && typeof value === 'boolean')
+      (key === 'WEB_REQUEST' && typeof value === 'object') ||
+      (key !== 'WEB_REQUEST' && typeof value === 'boolean')
     ) {
       // $FlowFixMe: value polymorphism
       permissions[key] = value
@@ -163,10 +163,10 @@ export default class App {
     const requiredPermissions = this.manifest.permissions.required
     const appPermissions = {
       ...requiredPermissions,
-      HTTPS_REQUEST: createHTTPSRequestGrant(requiredPermissions.HTTPS_REQUEST),
+      WEB_REQUEST: createWebRequestGrant(requiredPermissions.WEB_REQUEST),
     }
     const userPermissions = this.getPermissions(userID) || {
-      HTTPS_REQUEST: createHTTPSRequestGrant(),
+      WEB_REQUEST: createWebRequestGrant(),
     }
     const permissions = mergeGrantsToDetails(appPermissions, userPermissions)
     const session = new Session(this._appID, userID, permissions.session)

--- a/packages/daemon/src/rpc/methods/identity.js
+++ b/packages/daemon/src/rpc/methods/identity.js
@@ -9,22 +9,32 @@ type OwnId = {
   data: Object,
 }
 
-export const createDeveloper = async (
-  ctx: RequestContext,
-  [data]: [Object] = [],
-): Promise<{ id: ID }> => {
-  const id = ctx.openVault.identities.createOwnDeveloper(data)
-  await ctx.openVault.save()
-  return { id }
+export const createDeveloper = {
+  params: {
+    data: 'any', // TODO: data schema
+  },
+  handler: async (
+    ctx: RequestContext,
+    params: { data: Object },
+  ): Promise<{ id: ID }> => {
+    const id = ctx.openVault.identities.createOwnDeveloper(params.data)
+    await ctx.openVault.save()
+    return { id }
+  },
 }
 
-export const createUser = async (
-  ctx: RequestContext,
-  [data]: [Object] = [],
-): Promise<{ id: ID }> => {
-  const id = ctx.openVault.identities.createOwnUser(data)
-  await ctx.openVault.save()
-  return { id }
+export const createUser = {
+  params: {
+    data: 'any', // TODO: data schema
+  },
+  handler: async (
+    ctx: RequestContext,
+    params: { data: Object },
+  ): Promise<{ id: ID }> => {
+    const id = ctx.openVault.identities.createOwnUser(params.data)
+    await ctx.openVault.save()
+    return { id }
+  },
 }
 
 export const getOwnUsers = (ctx: RequestContext): { users: Array<OwnId> } => {

--- a/packages/daemon/src/rpc/methods/index.js
+++ b/packages/daemon/src/rpc/methods/index.js
@@ -26,7 +26,6 @@ export default {
   // - "remove": clear + also removes manifest, no more knowledge about this app in vault
   app_uninstall: noop,
   app_update: noop, // TODO: similar to install
-  app_validateManifest: app.validateManifestData,
   identity_createUser: identity.createUser,
   identity_createDeveloper: identity.createDeveloper,
   identity_getOwnUsers: identity.getOwnUsers,

--- a/packages/daemon/src/rpc/methods/parameters.js
+++ b/packages/daemon/src/rpc/methods/parameters.js
@@ -1,0 +1,6 @@
+// @flow
+
+export const localIdParam = {
+  type: 'string',
+  length: 21, // nanoid generates 21-chars long strings
+}

--- a/packages/daemon/src/rpc/methods/subscription.js
+++ b/packages/daemon/src/rpc/methods/subscription.js
@@ -4,6 +4,13 @@ import type { ID } from '@mainframe/utils-id'
 
 import type RequestContext from '../RequestContext'
 
-export const unsubscribe = (ctx: RequestContext, [id]: [ID] = []): void => {
-  ctx.removeSubscription(id)
+import { localIdParam } from './parameters'
+
+export const unsubscribe = {
+  params: {
+    id: localIdParam,
+  },
+  handler: (ctx: RequestContext, params: { id: ID }): void => {
+    ctx.removeSubscription(params.id)
+  },
 }

--- a/packages/daemon/src/rpc/methods/vault.js
+++ b/packages/daemon/src/rpc/methods/vault.js
@@ -3,26 +3,41 @@
 import { vaultError } from '../errors'
 import type RequestContext from '../RequestContext'
 
-export const create = async (
-  ctx: RequestContext,
-  [path, password]: [string, string] = [],
-) => {
-  try {
-    await ctx.vaults.create(ctx.socket, path, Buffer.from(password))
-  } catch (err) {
-    // TODO: different error code depending on actual error
-    throw vaultError(err.message)
-  }
+const vaultParams = {
+  path: { type: 'string', empty: false },
+  password: { type: 'string', empty: false },
 }
 
-export const open = async (
-  ctx: RequestContext,
-  [path, password]: [string, string] = [],
-) => {
-  try {
-    await ctx.vaults.open(ctx.socket, path, Buffer.from(password))
-  } catch (err) {
-    // TODO: different error code depending on actual error
-    throw vaultError(err.message)
-  }
+type VaultParams = { path: string, password: string }
+
+export const create = {
+  params: vaultParams,
+  handler: async (ctx: RequestContext, params: VaultParams) => {
+    try {
+      await ctx.vaults.create(
+        ctx.socket,
+        params.path,
+        Buffer.from(params.password),
+      )
+    } catch (err) {
+      // TODO: different error code depending on actual error
+      throw vaultError(err.message)
+    }
+  },
+}
+
+export const open = {
+  params: vaultParams,
+  handler: async (ctx: RequestContext, params: VaultParams) => {
+    try {
+      await ctx.vaults.open(
+        ctx.socket,
+        params.path,
+        Buffer.from(params.password),
+      )
+    } catch (err) {
+      // TODO: different error code depending on actual error
+      throw vaultError(err.message)
+    }
+  },
 }

--- a/packages/daemon/src/rpc/methods/web3.js
+++ b/packages/daemon/src/rpc/methods/web3.js
@@ -8,19 +8,19 @@ import web3Client from '../web3Client'
 
 export const request = async (
   ctx: RequestContext,
-  [sessID, method, params, granted]: [ID, string, any, ?boolean] = [],
+  params: { sessID: ID, method: string, params: any, granted: ?boolean },
 ): Promise<?mixed> => {
-  const session = ctx.openVault.getSession(sessID)
+  const session = ctx.openVault.getSession(params.sessID)
   if (session == null) {
     throw clientError('Invalid session')
   }
 
-  if (granted !== true) {
+  if (params.granted !== true) {
     const result = session.checkPermission('WEB3_CALL')
     if (result !== 'granted') {
       throw permissionErrorFromResult(result)
     }
   }
 
-  return web3Client.request(method, params)
+  return web3Client.request(params.method, params.params)
 }

--- a/packages/launcher/package.json
+++ b/packages/launcher/package.json
@@ -30,9 +30,9 @@
     "@mainframe/toolbox": "*",
     "electron-util": "^0.9.0",
     "fs-extra": "^7.0.0",
-    "react": "^16.4.0",
-    "react-art": "^16.4.0",
-    "react-dom": "^16.4.0",
+    "react": "^16.4.2",
+    "react-art": "^16.4.2",
+    "react-dom": "^16.4.2",
     "react-modal": "^3.4.5",
     "react-native-web": "^0.8.0",
     "source-map-support": "^0.5.5"
@@ -43,12 +43,12 @@
     "@babel/preset-react": "7.0.0-beta.47",
     "@mainframe/utils-id": "^0.1.0",
     "babel-plugin-react-native-web": "^0.8.6",
-    "electron": "^2.0.2",
-    "electron-builder": "^20.16.0",
+    "electron": "^2.0.6",
+    "electron-builder": "^20.26.1",
     "electron-webpack": "^2.1.2",
     "flow-bin": "^0.77.0",
     "mocha": "^5.2.0",
     "spectron": "^3.8.0",
-    "webpack": "^4.14.0"
+    "webpack": "^4.16.4"
   }
 }

--- a/packages/launcher/src/renderer/launcher/PermissionsView.js
+++ b/packages/launcher/src/renderer/launcher/PermissionsView.js
@@ -1,7 +1,7 @@
 //@flow
 
 import {
-  createHTTPSRequestGrant,
+  createWebRequestGrant,
   type PermissionKey, // eslint-disable-line import/named
   type PermissionRequirement, // eslint-disable-line import/named
   type PermissionsGrants, // eslint-disable-line import/named
@@ -21,7 +21,7 @@ type Domain = string
 type PermissionGranted = boolean
 
 type PermissionOption = {
-  HTTPS_REQUEST?: Array<Domain>,
+  WEB_REQUEST?: Array<Domain>,
   [PermissionKey]: true,
 }
 
@@ -34,7 +34,7 @@ export type PermissionOptions = {
 
 // Permissions set by user
 type PermissionsSettings = {
-  HTTPS_REQUEST: { [Domain]: PermissionGranted },
+  WEB_REQUEST: { [Domain]: PermissionGranted },
   [PermissionKey]: PermissionGranted,
 }
 
@@ -56,9 +56,9 @@ const PERMISSION_NAMES = {
     description:
       'Allow this app to make transactional calls to the blockchain, e.g. send tokens',
   },
-  HTTPS_REQUEST: {
-    name: 'Make https requests',
-    description: 'Allow this app to make https requests to specified domains',
+  WEB_REQUEST: {
+    name: 'Make Web requests',
+    description: 'Allow this app to make Web requests to specified domains',
   },
   NOTIFICATION_DISPLAY: {
     name: 'Display Notifications',
@@ -73,15 +73,15 @@ const PERMISSION_NAMES = {
 const formatSettings = (
   settings: $Shape<PermissionsSettings>,
 ): $Shape<PermissionsGrants> => {
-  const { HTTPS_REQUEST, ...others } = settings
-  const domains = Object.keys(HTTPS_REQUEST)
-  const granted = domains.filter(k => HTTPS_REQUEST[k])
-  const denied = domains.filter(k => !HTTPS_REQUEST[k])
+  const { WEB_REQUEST, ...others } = settings
+  const domains = Object.keys(WEB_REQUEST)
+  const granted = domains.filter(k => WEB_REQUEST[k])
+  const denied = domains.filter(k => !WEB_REQUEST[k])
   return {
     ...others,
-    HTTPS_REQUEST: HTTPS_REQUEST
-      ? createHTTPSRequestGrant(granted, denied)
-      : createHTTPSRequestGrant(),
+    WEB_REQUEST: WEB_REQUEST
+      ? createWebRequestGrant(granted, denied)
+      : createWebRequestGrant(),
   }
 }
 
@@ -99,7 +99,7 @@ export default class PermissionsView extends Component<Props, State> {
   state = {
     failedValidation: false,
     permissionsSettings: {
-      HTTPS_REQUEST: {},
+      WEB_REQUEST: {},
     },
   }
 
@@ -109,10 +109,10 @@ export default class PermissionsView extends Component<Props, State> {
     const { permissions } = this.props
     const { permissionsSettings } = this.state
     const settings = formatSettings(permissionsSettings)
-    const requiredDomains = permissions.required['HTTPS_REQUEST']
+    const requiredDomains = permissions.required.WEB_REQUEST
     if (requiredDomains && requiredDomains.length) {
-      settings['HTTPS_REQUEST'].granted.push(...requiredDomains)
-      delete permissions.required['HTTPS_REQUEST']
+      settings.WEB_REQUEST.granted.push(...requiredDomains)
+      delete permissions.required.WEB_REQUEST
     }
     this.props.onSubmit({ ...settings, ...permissions.required })
   }
@@ -123,14 +123,14 @@ export default class PermissionsView extends Component<Props, State> {
     option?: string,
   ) => {
     this.setState(({ permissionsSettings }) => {
-      if (key === 'HTTPS_REQUEST') {
+      if (key === 'WEB_REQUEST') {
         if (option == null) {
           return null // Don't update state
         }
         if (granted == null) {
-          delete permissionsSettings.HTTPS_REQUEST[option]
+          delete permissionsSettings.WEB_REQUEST[option]
         } else {
-          permissionsSettings.HTTPS_REQUEST[option] = granted
+          permissionsSettings.WEB_REQUEST[option] = granted
         }
       } else {
         if (granted == null) {
@@ -211,7 +211,7 @@ export default class PermissionsView extends Component<Props, State> {
     const { permissionsSettings } = this.state
     let options, rowStyle
 
-    if (key === 'HTTPS_REQUEST') {
+    if (key === 'WEB_REQUEST') {
       if (Array.isArray(value)) {
         options = (
           <View key={key} style={styles.domains}>
@@ -224,8 +224,8 @@ export default class PermissionsView extends Component<Props, State> {
                   {required
                     ? this.renderRequired()
                     : this.renderToggle(
-                        'HTTPS_REQUEST',
-                        permissionsSettings.HTTPS_REQUEST[domain],
+                        'WEB_REQUEST',
+                        permissionsSettings.WEB_REQUEST[domain],
                         domain,
                       )}
                 </View>

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,11 +792,24 @@
   dependencies:
     "@mainframe/utils-id" "^0.1.1"
 
-"@mainframe/rpc-error@^0.1.0", "@mainframe/rpc-error@^0.1.1":
+"@mainframe/rpc-error@^0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@mainframe/rpc-error/-/rpc-error-0.1.1.tgz#fe7c00bc96079356662992d9bd553c116e12fcee"
   dependencies:
     es6-error "^4.1.1"
+
+"@mainframe/rpc-error@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@mainframe/rpc-error/-/rpc-error-0.2.1.tgz#70c90aa316ae17284ee03038625e7c6333868b72"
+  dependencies:
+    es6-error "^4.1.1"
+
+"@mainframe/rpc-handler@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@mainframe/rpc-handler/-/rpc-handler-0.1.0.tgz#0a7ced4840b89049309ebb2dd6a35971319236ac"
+  dependencies:
+    "@mainframe/rpc-error" "^0.2.1"
+    fastest-validator "^0.6.10"
 
 "@mainframe/rpc-http-node@^0.1.1":
   version "0.1.1"
@@ -805,12 +818,19 @@
     "@mainframe/rpc-request" "^0.1.2"
     "@mainframe/transport-http-node" "^0.1.1"
 
-"@mainframe/rpc-ipc@^0.2.0", "@mainframe/rpc-ipc@^0.2.1":
+"@mainframe/rpc-ipc@^0.2.1":
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@mainframe/rpc-ipc/-/rpc-ipc-0.2.1.tgz#c8aa6d80dd3c868ed2d871e560eea873de899a56"
   dependencies:
     "@mainframe/rpc-stream" "^0.2.4"
     "@mainframe/transport-ipc" "^0.2.1"
+
+"@mainframe/rpc-ipc@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@mainframe/rpc-ipc/-/rpc-ipc-0.2.3.tgz#7b2ab6f64a6ef53a4cc962f7945cdb093919efc7"
+  dependencies:
+    "@mainframe/rpc-stream" "^0.2.4"
+    "@mainframe/transport-ipc" "^0.2.3"
 
 "@mainframe/rpc-node@^0.2.0":
   version "0.2.1"
@@ -865,6 +885,12 @@
   resolved "https://registry.yarnpkg.com/@mainframe/transport-ipc/-/transport-ipc-0.2.1.tgz#c45d7c7d4a0bf5f43c8b34f32755af3c6974a953"
   dependencies:
     rx-socket "^0.3.1"
+
+"@mainframe/transport-ipc@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@mainframe/transport-ipc/-/transport-ipc-0.2.3.tgz#b75f759c25d0f976af4021f32dd359aff4364af7"
+  dependencies:
+    rx-socket "^0.4.0"
 
 "@mainframe/transport-ws-node@^0.3.1":
   version "0.3.2"
@@ -1304,38 +1330,7 @@ app-builder-bin@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-2.0.0.tgz#bda985bee14370b254841a9982753b8f383415c5"
 
-app-builder-lib@20.26.0:
-  version "20.26.0"
-  resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-20.26.0.tgz#551667e1924f43da48399703f492ca8a35666a9e"
-  dependencies:
-    "7zip-bin" "~4.0.2"
-    app-builder-bin "2.0.0"
-    async-exit-hook "^2.0.1"
-    bluebird-lst "^1.0.5"
-    builder-util "5.20.0"
-    builder-util-runtime "4.4.1"
-    chromium-pickle-js "^0.2.0"
-    debug "^3.1.0"
-    ejs "^2.6.1"
-    electron-osx-sign "0.4.10"
-    electron-publish "20.26.0"
-    env-paths "^1.0.0"
-    fs-extra-p "^4.6.1"
-    hosted-git-info "^2.7.1"
-    is-ci "^1.1.0"
-    isbinaryfile "^3.0.2"
-    js-yaml "^3.12.0"
-    lazy-val "^1.0.3"
-    minimatch "^3.0.4"
-    normalize-package-data "^2.4.0"
-    plist "^3.0.1"
-    read-config-file "3.1.0"
-    sanitize-filename "^1.6.1"
-    semver "^5.5.0"
-    sumchecker "^2.0.2"
-    temp-file "^3.1.3"
-
-app-builder-lib@~20.26.0:
+app-builder-lib@20.26.1, app-builder-lib@~20.26.0:
   version "20.26.1"
   resolved "https://registry.yarnpkg.com/app-builder-lib/-/app-builder-lib-20.26.1.tgz#5165875e23436244a287594676235a25f8d15bd9"
   dependencies:
@@ -1608,10 +1603,6 @@ babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@7.0.0-bridge.0:
-  version "7.0.0-bridge.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-7.0.0-bridge.0.tgz#95a492ddd90f9b4e9a4a1da14eb335b87b634ece"
-
 babel-core@^6.0.0, babel-core@^6.26.0:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
@@ -1778,7 +1769,7 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^23.4.0, babel-jest@^23.4.2:
+babel-jest@^23.4.2:
   version "23.4.2"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.2.tgz#f276de67798a5d68f2d6e87ff518c2f6e1609877"
   dependencies:
@@ -2294,10 +2285,6 @@ babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babel@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel/-/babel-6.23.0.tgz#d0d1e7d803e974765beea3232d4e153c0efb90f4"
-
 babylon@7.0.0-beta.44:
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
@@ -2654,25 +2641,6 @@ builder-util-runtime@4.4.1, builder-util-runtime@^4.4.1:
     debug "^3.1.0"
     fs-extra-p "^4.6.1"
     sax "^1.2.4"
-
-builder-util@5.20.0:
-  version "5.20.0"
-  resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-5.20.0.tgz#dadce32c57036eb9f9c6f1139a76cbc63f6d7582"
-  dependencies:
-    "7zip-bin" "~4.0.2"
-    app-builder-bin "2.0.0"
-    bluebird-lst "^1.0.5"
-    builder-util-runtime "^4.4.1"
-    chalk "^2.4.1"
-    debug "^3.1.0"
-    fs-extra-p "^4.6.1"
-    is-ci "^1.1.0"
-    js-yaml "^3.12.0"
-    lazy-val "^1.0.3"
-    semver "^5.5.0"
-    source-map-support "^0.5.6"
-    stat-mode "^0.2.2"
-    temp-file "^3.1.3"
 
 builder-util@5.20.1, builder-util@~5.20.0:
   version "5.20.1"
@@ -4234,13 +4202,13 @@ ejs@~2.5.6:
   version "2.5.9"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.9.tgz#7ba254582a560d267437109a68354112475b0ce5"
 
-electron-builder@^20.16.0:
-  version "20.26.0"
-  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.26.0.tgz#8ae1ff1b8265423a6dd6d8e904a32ab00a61e8f4"
+electron-builder@^20.26.1:
+  version "20.26.1"
+  resolved "https://registry.yarnpkg.com/electron-builder/-/electron-builder-20.26.1.tgz#a8a99fc6484547b9ee62cee79adeea665707523c"
   dependencies:
-    app-builder-lib "20.26.0"
+    app-builder-lib "20.26.1"
     bluebird-lst "^1.0.5"
-    builder-util "5.20.0"
+    builder-util "5.20.1"
     builder-util-runtime "4.4.1"
     chalk "^2.4.1"
     dmg-builder "5.1.0"
@@ -4375,9 +4343,9 @@ electron-webpack@^2.1.2:
     webpack-merge "^4.1.2"
     yargs "^11.1.0"
 
-electron@^2.0.2:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.5.tgz#6045db011e2547062a36e8c5da84d4982f434fc0"
+electron@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-2.0.6.tgz#8e5c1bd2ebc08fa7a6ee906de3753c1ece9d7300"
   dependencies:
     "@types/node" "^8.0.24"
     electron-download "^3.0.1"
@@ -4676,7 +4644,7 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^5.0.1:
+eslint@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.2.0.tgz#3901ae249195d473e633c4acbc370068b1c964dc"
   dependencies:
@@ -4720,9 +4688,9 @@ eslint@^5.0.1:
     table "^4.0.3"
     text-table "^0.2.0"
 
-esm@3.0.72:
-  version "3.0.72"
-  resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.72.tgz#8f71b3f54b978bbbcbb9788f7f3569a36578c136"
+esm@3.0.74:
+  version "3.0.74"
+  resolved "https://registry.yarnpkg.com/esm/-/esm-3.0.74.tgz#d9b5ac6d6b210068a41337373b002c502c824fbf"
 
 espree@^3.1.3:
   version "3.5.4"
@@ -5030,6 +4998,10 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fastest-validator@^0.6.10:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/fastest-validator/-/fastest-validator-0.6.10.tgz#1d120c2fa9afd73612911db099ff707c028f8461"
 
 fastparse@^1.1.1:
   version "1.1.1"
@@ -5974,6 +5946,10 @@ http-errors@~1.6.2:
     inherits "2.0.3"
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
+
+http-https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/http-https/-/http-https-1.0.0.tgz#2f908dd5f1db4068c058cd6e6d4ce392c913389b"
 
 http-parser-js@>=0.4.0:
   version "0.4.13"
@@ -8205,6 +8181,12 @@ object.values@^1.0.4:
     function-bind "^1.1.0"
     has "^1.0.1"
 
+oboe@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/oboe/-/oboe-2.1.4.tgz#20c88cdb0c15371bb04119257d4fdd34b0aa49f6"
+  dependencies:
+    http-https "^1.0.0"
+
 obuf@^1.0.0, obuf@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
@@ -9133,9 +9115,9 @@ rc@^1.0.1, rc@^1.1.2, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-art@^16.4.0:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-art/-/react-art-16.4.1.tgz#3544c13038d7ddfe8b1cc1170b02d99492c03b50"
+react-art@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-art/-/react-art-16.4.2.tgz#df6846dab6e11ef13ae07d33d64cff50925de2da"
   dependencies:
     art "^0.10.1"
     create-react-class "^15.6.2"
@@ -9144,9 +9126,9 @@ react-art@^16.4.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react-dom@^16.4.0:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.1.tgz#7f8b0223b3a5fbe205116c56deb85de32685dad6"
+react-dom@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.4.2.tgz#4afed569689f2c561d2b8da0b819669c38a0bda4"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -9185,9 +9167,9 @@ react-timer-mixin@^0.13.3:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/react-timer-mixin/-/react-timer-mixin-0.13.4.tgz#75a00c3c94c13abe29b43d63b4c65a88fc8264d3"
 
-react@^16.4.0:
-  version "16.4.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.1.tgz#de51ba5764b5dbcd1f9079037b862bd26b82fe32"
+react@^16.4.2:
+  version "16.4.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.4.2.tgz#2cd90154e3a9d9dd8da2991149fdca3c260e129f"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"
@@ -9704,6 +9686,12 @@ rx-lite@*, rx-lite@^4.0.8:
 rx-socket@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/rx-socket/-/rx-socket-0.3.1.tgz#aa8a61af14d73c8a2abfbf22f0450ab30b2de9c3"
+
+rx-socket@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/rx-socket/-/rx-socket-0.4.0.tgz#59168398f594d5914d8fdad7f5713796060b3350"
+  dependencies:
+    oboe "^2.1.4"
 
 rxjs@^5.5.2:
   version "5.5.11"
@@ -11249,9 +11237,9 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.14.0:
-  version "4.16.3"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.16.3.tgz#861be3176d81e7e3d71c66c8acc9bba35588b525"
+webpack@^4.16.4:
+  version "4.16.4"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.16.4.tgz#6b020f76483bc66339164c296d89978aa100d37a"
   dependencies:
     "@webassemblyjs/ast" "1.5.13"
     "@webassemblyjs/helper-module-context" "1.5.13"


### PR DESCRIPTION
@avclarke part of these changes include updating `rpc-ipc` in the client to use the `rx-socket` changes so it might be useful to you as well.
I also renamed the `HTTPS_REQUEST` permission to `WEB_REQUEST` as I think it would include both HTTPS and WebSocket, so you may need to replace your vault as well.

Closes https://github.com/MainframeHQ/js-mainframe/issues/30