### PR TITLE
things I needed to do to onboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ coverage
 dist/
 *.log
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This project is in alpha, lots of breaking changes are to be expected between re
 
 - [Node](https://nodejs.org/en/) v10+ (includes npm)
 - [Yarn](https://yarnpkg.com/lang/en/) (optional - faster alternative to npm)
+- [Homebrew](https://brew.sh/) for mac setup
 
 ### Setup
 
@@ -39,6 +40,8 @@ Each package contains (or will contain) a readme with further information pertai
 In the root of the project, install node dependencies:
 
 ```
+brew update && brew upgrade
+brew install libtool autoconf automake
 yarn install
 yarn bootstrap
 yarn build

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ This project is in alpha, lots of breaking changes are to be expected between re
 
 - [Node](https://nodejs.org/en/) v10+ (includes npm)
 - [Yarn](https://yarnpkg.com/lang/en/) (optional - faster alternative to npm)
-- [Homebrew](https://brew.sh/) for mac setup
 
 ### Setup
 
@@ -40,8 +39,6 @@ Each package contains (or will contain) a readme with further information pertai
 In the root of the project, install node dependencies:
 
 ```
-brew update && brew upgrade
-brew install libtool autoconf automake
 yarn install
 yarn bootstrap
 yarn build

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-config-mainframe": "^2.1.0",
     "flow-bin": "^0.81.0",
     "flow-copy-source": "^2.0.1",
-    "flow-mono-cli": "^1.4.2",
+    "flow-mono-cli": "^1.4.3",
     "flow-remove-types": "^1.2.3",
     "flow-typed": "^2.4.0",
     "jest": "^23.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7113,10 +7113,10 @@ flow-copy-source@^2.0.1:
     kefir "^3.7.3"
     yargs "^12.0.1"
 
-flow-mono-cli@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/flow-mono-cli/-/flow-mono-cli-1.4.2.tgz#6046938f8125e8eb35fd3ed2a19ab069c601c89e"
-  integrity sha512-oMR9iNFy4vQA1E57R5RvHvSjdPXCxPgUhr6uBVSoXLwNe+6eF2yi5eCWtnmPBTks8PUedaHg5XXYa4hinsr7sw==
+flow-mono-cli@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/flow-mono-cli/-/flow-mono-cli-1.4.3.tgz#72947ccf83bb652ee2252dae23859a08f8117b1b"
+  integrity sha512-L9fDIbfOB0Szutu8qM6qcHKf6eIxH+N669fWnZ4K4BMskrAgylN0cUYlqduXa0A9UkyUJKSDmB4uIi9rMMYBqQ==
   dependencies:
     cosmiconfig "5.0.6"
     debug-logger "0.4.1"


### PR DESCRIPTION
Following the instructions as is I ran into these errors: 

```
yarn install v1.12.1
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
warning "eslint-config-mainframe > eslint-plugin-react-native@3.2.1" has incorrect peer dependency "eslint@^3.17.0 || ^4.0.0".
[4/4] 📃  Building fresh packages...
[1/7] ⠐ fsevents
[2/7] ⠐ sodium-native
[3/7] ⠐ sha3
[4/7] ⠐ websocket
warning Error running install script for optional dependency: "/Users/doug/apps/mainframe/js-mainframe/node_modules/sodium-native: Command failed.
Exit code: 1
Command: node-gyp-build \"node preinstall.js\" \"node postinstall.js\"
Arguments:
Directory: /Users/doug/apps/mainframe/js-mainframe/node_modules/sodium-native
Output:
libtool is required, but wasn't found on this system
./configure: line 5: ./configure: No such file or directory
/Users/doug/apps/mainframe/js-mainframe/node_modules/sodium-native/preinstall.js:87
    if (err) throw err
             ^
Error: ./configure exited with 127
```
**libtool is required, but wasn't found on this system**
So to fix this I ran the following command.
> brew install libtool autoconf automake

```
$ flow-mono create-symlinks .flowconfig
/bin/sh: flow-mono: command not found
error Command failed with exit code 127.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
To fix this I needed to update the flow-cli dependancy.

So this pull request are the things that needed to change to onboard my computer.