### PR TITLE
Add requirements for the Linux build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ This project is in alpha, lots of breaking changes are to be expected between re
 ### Prerequisites
 
 - [Node](https://nodejs.org/en/) v10+ (includes npm)
+- Installed git and added to PATH environment variable
+- #### Linux
+  `sudo apt install -y libudev-dev libtool libusb-1.0-0-dev build-essential`
 
 ### Setup
 


### PR DESCRIPTION
Also the git is necessary to have, as the build scripts clone the ethereum packages. We know it's on almost all Unix systems by default, but sadly is missing on the Windows.

Fixes issue https://github.com/MainframeHQ/js-mainframe/issues/155