### PR TITLE
Fix windows build

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ This project is in alpha, lots of breaking changes are to be expected between re
 ### Prerequisites
 
 - [Node](https://nodejs.org/en/) v10+ (includes npm)
+- Installed git and added to PATH environment variable
+- #### Windows
+  ``npm install --global --production windows-build-tools``
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -53,12 +53,20 @@ Next, a local environment must be created. An environment contains references to
 ```
 packages/cli/bin/run env:create
 ```
+Or on Windows
+```
+"packages/cli/bin/run.cmd" env:create
+```
 
 This first environment should be created with the `development` type and set as default environment.
 The newly created environment then needs to be configured using the CLI:
 
 ```
 packages/cli/bin/run daemon:setup --bin-path=./packages/daemon/bin/run
+```
+Or on Windows
+```
+"packages/cli/bin/run.cmd" daemon:setup --bin-path="packages/daemon/bin/run.cmd"
 ```
 
 ## Development
@@ -73,6 +81,10 @@ Now, in one terminal tab, run the daemon:
 
 ```
 ./packages/cli/bin/run daemon:start
+```
+Or on Windows
+```
+"packages/cli/bin/run.cmd" daemon:start
 ```
 
 Then, in another tab, run the launcher:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3907,6 +3907,31 @@
         "capture-stack-trace": "^1.0.0"
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
+    "cross-env": "^5.2.0",
     "del-cli": "^1.1.0",
     "eslint": "^5.6.1",
     "eslint-config-mainframe": "^2.3.0",

--- a/packages/app-manifest/package.json
+++ b/packages/app-manifest/package.json
@@ -4,7 +4,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
-    "clean": "del lib",
+    "clean": "del-cli lib",
     "build:js": "flow-remove-types src --out-dir lib",
     "build:flow": "flow-copy-source src lib",
     "build": "npm run clean && npm run build:js && npm run build:flow",

--- a/packages/app-permissions/package.json
+++ b/packages/app-permissions/package.json
@@ -4,7 +4,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
-    "clean": "del lib",
+    "clean": "del-cli lib",
     "build:js": "flow-remove-types src --out-dir lib",
     "build:flow": "flow-copy-source src lib",
     "build": "npm run clean && npm run build:js && npm run build:flow",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,8 +20,8 @@
     ]
   },
   "scripts": {
-    "clean": "del lib",
-    "build:js": "babel src --out-dir lib",
+    "clean": "del-cli lib",
+    "build:js": "cross-env BABEL_ENV=browser-cjs babel src --out-dir lib",
     "build:flow": "flow-copy-source src lib",
     "build": "npm run clean && npm run build:js && npm run build:flow",
     "test:types": "flow check"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -4,7 +4,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
-    "clean": "del lib",
+    "clean": "del-cli lib",
     "build:js": "flow-remove-types src --out-dir lib",
     "build:flow": "flow-copy-source src lib",
     "build": "npm run clean && npm run build:js && npm run build:flow",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -4,7 +4,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
-    "clean": "del lib",
+    "clean": "del-cli lib",
     "build:js": "flow-remove-types src --out-dir lib",
     "build:flow": "flow-copy-source src lib",
     "build": "npm run clean && npm run build:js && npm run build:flow",

--- a/packages/contract-utils/package.json
+++ b/packages/contract-utils/package.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "main": "cjs/index.js",
   "scripts": {
-    "clean": "del cjs && del dist",
+    "clean": "del-cli cjs dist",
     "webpack": "webpack",
-    "build:dist": "BABEL_ENV='browser-esm' npm run webpack",
-    "build:cjs": "BABEL_ENV='browser-cjs' babel src --out-dir cjs",
+    "build:dist": "cross-env BABEL_ENV=browser-esm npm run webpack",
+    "build:cjs": "cross-env BABEL_ENV=browser-cjs babel src --out-dir cjs",
     "build:flow": "flow-copy-source src cjs",
     "build": "npm run clean && npm run build:dist && npm run build:cjs && npm run build:flow",
     "test:types": "flow check"

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -18,8 +18,8 @@
     ]
   },
   "scripts": {
-    "clean": "del lib",
-    "build:js": "babel src --out-dir lib",
+    "clean": "del-cli lib",
+    "build:js": "cross-env BABEL_ENV=browser-cjs babel src --out-dir lib",
     "build:flow": "flow-copy-source src lib",
     "build": "npm run clean && npm run build:js && npm run build:flow",
     "test:types": "flow check",

--- a/packages/data-types/package.json
+++ b/packages/data-types/package.json
@@ -4,8 +4,8 @@
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
-    "clean": "del lib",
-    "build:js": "babel src --out-dir lib",
+    "clean": "del-cli lib",
+    "build:js": "cross-env BABEL_ENV=browser-cjs babel src --out-dir lib",
     "build:flow": "flow-copy-source src lib",
     "build": "npm run clean && npm run build:js && npm run build:flow",
     "test:types": "flow check"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -4,10 +4,10 @@
   "main": "cjs/index.js",
   "license": "MIT",
   "scripts": {
-    "clean": "del cjs && del dist",
+    "clean": "del-cli cjs dist",
     "webpack": "webpack",
-    "build:dist": "BABEL_ENV='browser-esm' npm run webpack",
-    "build:cjs": "BABEL_ENV='browser-cjs' babel src --out-dir cjs",
+    "build:dist": "cross-env BABEL_ENV=browser-esm npm run webpack",
+    "build:cjs": "cross-env BABEL_ENV=browser-cjs babel src --out-dir cjs",
     "build:flow": "flow-copy-source src cjs",
     "build:sdk": "npm run clean && npm run build:dist && npm run build:cjs && npm run build:flow",
     "test:types": "flow check"

--- a/packages/toolbox/package.json
+++ b/packages/toolbox/package.json
@@ -4,7 +4,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
-    "clean": "del lib",
+    "clean": "del-cli lib",
     "build:js": "flow-remove-types src --out-dir lib",
     "build:flow": "flow-copy-source src lib",
     "build": "npm run clean && npm run build:js && npm run build:flow",


### PR DESCRIPTION
This fixes issue https://github.com/MainframeHQ/js-mainframe/issues/126

As you know on Windows you have to set the environment variables different way than on Linux. Those commands are in multiple package.json scripts. Luckily there is multiplatform package which solves this issue https://www.npmjs.com/package/cross-env

We also changed:
```
 "clean": "del lib",
```
To
```
clean": "del-cli lib",
```

As the del command is not script friendly on Windows and requires user input (confirmation). You already had del-cli package in your modules so we just used it. 

These changes were tested on:
- Windows 10
- Linux Ubuntu 18.04
- macOS  HighSierra 10.13.5